### PR TITLE
F/update tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,10 @@ example.py
 example2.py
 example3.py
 test_all_models.py
+
+
+#jupyter stuff
+.ipynb_checkpoints
+
+# .onnx models
+*.onnx

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![PyPI Release](https://github.com/scailable/sclblpy/workflows/PyPI%20Release/badge.svg)](https://pypi.org/project/sclblpy/)
 
+
+DISCLAIMER: Sclblpy is undergoing changes, most notably we will focus on .onnx from now on, meaning sklearn and similar packages are no longer supported as well as the removal of the `run()` function.
+Expect unstable APIs!
+If you're the maintainer of a project and run into problems, feel free to send us a message at support@scailable.net
+
 `sclblpy` is the core python package provided by Scailable for interacting with our API. The scope of this package is (roughly):
 1. upload an `.onnx` model to the admin console
 2. Assign and deploy the uploaded model to a device that has previously been installed with the Scailable runtime and registered
@@ -169,7 +174,7 @@ the following packages:
 * `numpy`
 * `requests`
 * `uuid`
-* `sklearn`
+* `sklearn` (legacy, to be removed in future updates)
 
 No `onnx` packages are
 neccesary for the `sclblpy` package to run.

--- a/README.md
+++ b/README.md
@@ -2,31 +2,38 @@
 
 [![PyPI Release](https://github.com/scailable/sclblpy/workflows/PyPI%20Release/badge.svg)](https://pypi.org/project/sclblpy/)
 
-`sclblpy` is the core python package provided by Scailable to convert models fit in python to WebAssembly and
-open them up as a REST endpoint.
+`sclblpy` is the core python package provided by Scailable for interacting with our API. The scope of this package is (roughly):
+1. upload an `.onnx` model to the admin console
+2. Assign and deploy the uploaded model to a device that has previously been installed with the Scailable runtime and registered
+3. (upcoming) test device deployment
 
-Currently the package supports the upload of fitted `sklearn` model objects, and it supports uploading `.onnx` models
-(by specifying a path to the `.onnx` file). The package can also be used to manage assignments of models to 
-registered devices. 
+
+NOTE: the package is currently undergoing a major rework. We try to keep the below up to date, but some features might be stubs. 
+Most relevant is the removal of support for Scikit learn in favor of focussing fully on ONNX.
+
+Also, there will probably be breaking changes in the API in one of the upcoming releases.
+
 
 `sclblpy` is only functional in combination with a valid Scailable user account.
 
 - **Website:** [https://www.scailable.net](https://www.scailable.net)
 - **Docs:**
-   - On github: [https://github.com/scailable/sclblpy](https://github.com/scailable/sclblpy/blob/master/README.md)
+   - On github (you are here): [https://github.com/scailable/sclblpy](https://github.com/scailable/sclblpy/blob/master/README.md)
    - On pypi: [https://docs.sclbl.net/sclblpy](https://docs.sclbl.net/sclblpy)
-   - API docs Scailable: [https://docs.sclbl.net](https://docs.sclbl.net)
-- **Get an account:** [https://www.scailable.net](https://www.scailable.net?access-code=sclblpy-installation)
-- **Source:** [https://github.com/scailable/sclblpy/](https://github.com/scailable/sclblpy/)
-- **Getting started:** [https://github.com/scailable/sclbl-tutorials/tree/master/sclbl-101-getting-started](https://github.com/scailable/sclbl-tutorials/tree/master/sclbl-101-getting-started)
+   - API docs Scailable (no explanation of what the stuff does): [https://docs.sclbl.net](https://docs.sclbl.net)
+- **Get an account (page does not mention accounts, link destination is the same as above):** [https://admin.sclbl.net/signup.html](https://admin.sclbl.net/signup.html) 
+- **Install the AI manager:**
+   - Locally: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager)
+   - On an advantech device: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals)
 
 ## Background
-The sclblpy package allows users with a valid scailable account (apply for one at [https://www.scailable.net](https://www.scailable.net))
+The sclblpy package allows users with a valid scailable account (get one at [https://admin.sclbl.net/signup.html](https://admin.sclbl.net/signup.html)) 
 to upload fitted ML / AI models to the Scailable toolchain server. This will result in:
 
-1. The model being tested on the client side.
+1. The model being tested for errors on the client side.
 2. The model being uploaded to Scailable, tested again, and if all test pass it will be converted to [WebAssembly](https://webassembly.org).
-3. The model being made available as an easy to access REST endpoint.
+3. The model being made available to deploy to a pre-regsitered (link on how to do that) device
+4. (upcoming) The model being testable through test_run(example_input, device_id)
 
 ## Getting started
 
@@ -34,7 +41,7 @@ The following functions are likely most used:
 
 ### `sp.upload()` can be used to create model:
 ```python
-def upload(mod, features, docs={}, email=True, model_type="sklearn", _keep=False) -> bool:
+def upload(mod, features, docs={}, email=True, _keep=False) -> bool:
     """upload uploads a trained AI/ML model to Scailable.
 
     The upload function is the main workhorse of the sclblpy package but effectively provides a
@@ -81,120 +88,6 @@ def assign(cfid, did, rid, _verbose=True):
 ``` 
 `sp.assignments()` can be used to list current assignments, whereas `sp.delete_assignment()` can be used to delete an assignment. 
 
-## A simple example using `sklearn`
-After installing the package using `pip install sclblpy` you can easily fit a ML / AI model using your preferred tools and
-upload it to our toolchains. The following code block provides a simple example:
-
-````
-# Neccesary imports:
-import sclblpy as sp
-
-from sklearn import svm
-from sklearn import datasets
-
-# Start fitting a simple model:
-clf = svm.SVC()
-X, y = datasets.load_iris(return_X_y=True)
-clf.fit(X, y)
-
-# Create an example feature vector (required for sklearn models):
-row = X[130, :]
-
-# Create documentation (optional, but useful):
-docs = {}
-docs['name'] = "My first fitted model"
-docs['documentation'] = "Any documentation you would like to provide."
-
-# Upload the model:
-sp.upload(clf, row, docs=docs)
-````
-
-The call to `sp.upload()` will upload the fitted model, after running a number of local tests, to the 
-Scailable toolchain server and create an associated REST endpoint. Limited user feedback will be printed to show progress,
-and you will receive an email at the email address associated with your account when the conversion is fully completed (which might take a few minutes).
-This email also contains further details regarding the usage of your created endpoint.
-
-Note that upon first upload you will be prompted to provide your Scailable username and password; you can choose to
-store the provided credentials locally to enable easy login on subsequently uploads. (users can signup for an account at
- [https://www.scailable.net](https://www.scailable.net?access-code=sclblpy-installation)).
-
- 
-### More `sklearn` examples
-> These examples are merely intended to show the desired syntax for the various packages; we do not intend to fit models
-> that actually have a good predictive performance in these examples.
-
-Currently we support uploading `sklearn`, `statsmodels`, and `xgboost` models (run `sp.list_models()` to print an overview of all supported models). 
-Here we provide an example for each of these.
-
-### sklearn: the elastic net
-
-The [elastic net](https://web.stanford.edu/~hastie/Papers/elasticnet.pdf) provides a flexible regularized model that is 
-useful for many supervised learning tasks.
-
-````
-import sclblpy as sp
-from sklearn import linear_model  # Import linear_model
-from sklearn import datasets  # Import sklearn datasets
-
-iris_data = datasets.load_iris(return_X_y=True)
-X, y = iris_data
-
-mod = linear_model.ElasticNet()  # Instantiate the model
-
-mod.fit(X, y)  # Fit the model
-
-fv = X[0, :]  # An example feature vector
-docs = {'name': "ElasticNet example model", 'documentation' : "Documentation for this model."}
-
-sp.upload(mod, fv, docs)
-
-````
-
-### statsmodels: OLS regression
-
-The statsmodels package provides a number of regression models with flexible error functions. We provide a simple OLS
-example:
-
-```` 
-import sclblpy as sp
-
-import statsmodels.api as sm  # Import statsmodels
-from sklearn import datasets  # Import sklearn datasets
-
-iris_data = datasets.load_iris(return_X_y=True)
-X, y = iris_data
-
-est = sm.OLS(y, X)  # Specify the model
-mod = est.fit()  # Fit the model; note that we send the fitted model to scailable
-
-fv = X[0, :]  # An example feature vector
-docs = {'name': "OLS example model"}
-
-sp.upload(mod, fv, docs=docs)
-````
-
-### xgboost: tree boosting
-
-The xgboost package provides flexibly tree boosting models (see [xgboost](https://dl.acm.org/doi/abs/10.1145/2939672.2939785)).
-This model often performs very well "off the shelf" for many supervised learning tasks.
-
-```` 
-import sclblpy as sp
-
-from xgboost import XGBClassifier  # Import xgboost classifier
-from sklearn import datasets  # Import sklearn datasets
-
-iris_data = datasets.load_iris(return_X_y=True)
-X, y = iris_data
-
-mod = XGBClassifier()  # Instantiate the model
-mod.fit(X, y)  # Fit the model
-
-fv = X[0, :]  # An example feature vector
-docs = {'name': "XGBoost example model"}
-
-sp.upload(mod, fv, docs=docs)
-````
 
 ## A simple `.onnx` example
 
@@ -263,85 +156,6 @@ sp.remove_credentials()
 
 ````
 
-## Running an uploaded model
-After uploading a model to Scailable using the `sclblpy` package, you might also
-want to use `python` to consume the model. You will find example `python` code to consume
-your created endpiont in your [Scailable admin](https://admin.sclbl.net) which you can directly
-copy-paste into your python project. But, if you want it even easier you can also
-add the following to your code:
-
-````python
-from sclblpy import run
-
-cfid = "e93d0176-90f8-11ea-b602-9600004e79cc"  # This is the integer sum demo.
-fv = [1,2,3,4,5]
-result = run(cfid, fv)
-
-print(result) # Prints the full result from the Scailable server.
-````
-
-
-## Supported `sklearn` models
-
-The list of models supported by the current version of the `sclblpy` package can always be retrieved 
-using the `list_models()` function. Here we provide an overview:
-
-Package | Model | Tested (19-06-2020) | Note 
---- | --- | --- | --- 
-lightgbm | LGBMClassifier | ok |  
-lightgbm | LGBMRegressor | ok |  
-sklearn | ARDRegression | ok |  
-sklearn | BayesianRidge | ok |  
-sklearn | DecisionTreeClassifier | ok |  
-sklearn | DecisionTreeRegressor | ok |  
-sklearn | ElasticNet | ok |  
-sklearn | ElasticNetCV | ok |  
-sklearn | ExtraTreeClassifier | ok |  
-sklearn | ExtraTreeRegresso | ok |  
-sklearn | ExtraTreesClassifier | ok |  
-sklearn | ExtraTreesRegressor | ok |  
-sklearn | HuberRegressor | ok |  
-sklearn | Lars | ok |  
-sklearn | LarsCV | ok |  
-sklearn | Lasso | ok |  
-sklearn | LassoCV | ok |  
-sklearn | LassoLars | ok |  
-sklearn | LassoLarsCV | ok |  
-sklearn | LassoLarsIC | ok |  
-sklearn | LinearRegression | ok |  
-sklearn | LinearSVC | ok |  
-sklearn | LinearSVR | ok |  
-sklearn | LogisticRegression | ok |  
-sklearn | LogisticRegressionCV | ok |  
-sklearn | NuSVC | ok |  
-sklearn | NuSVR | ok |  
-sklearn | OrthogonalMatchingPursuit | ok |  
-sklearn | OrthogonalMatchingPursuitCV | ok |  
-sklearn | PassiveAggressiveClassifier | ok |  
-sklearn | PassiveAggressiveRegressor | ok |  
-sklearn | Perceptron | ok |  
-sklearn | RandomForestClassifier | ok |  
-sklearn | RandomForestRegressor | ok |  
-sklearn | RANSACRegressor | ok |  
-sklearn | Ridge | ok |  
-sklearn | RidgeClassifier | ok |  
-sklearn | RidgeClassifierCV | ok |  
-sklearn | RidgeCV | ok |  
-sklearn | SGDClassifier | ok |  
-sklearn | SGDRegressor | ok |  
-sklearn | SVC | ok |  
-sklearn | SVR | ok |  
-sklearn | TheilSenRegressor | ok |  
-statsmodels | Generalized Least Squares (GLS) | ok |  
-statsmodels | Generalized Least Squares with AR Errors (GLSAR) | ok |  
-statsmodels | Ordinary Least Squares (OLS) | ok |  
-statsmodels | Quantile Regression (QuantReg) | ok |  
-statsmodels | Weighted Least Squares (WLS) | ok |  
-xgboost | XGBClassifier | ok |  
-xgboost | XGBRegressor | ok |  
-xgboost | XGBRFClassifier | ok | Binary only
-xgboost | XGBRFRegressor | ok |  
-
 ## Supported `.onnx` files
 
 We currently support `ONNX` version 1.8 (and below) in full. However, if you encounter any problems
@@ -357,7 +171,7 @@ the following packages:
 * `uuid`
 * `sklearn`
 
-The `statsmodels` and `xgboost` packages are imported when used. No `onnx` packages are
+No `onnx` packages are
 neccesary for the `sclblpy` package to run.
 
 ## Notes:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Also, there will probably be breaking changes in the API in one of the upcoming 
 - **Docs:**
    - On github (you are here): [https://github.com/scailable/sclblpy](https://github.com/scailable/sclblpy/blob/master/README.md)
    - On pypi: [https://docs.sclbl.net/sclblpy](https://docs.sclbl.net/sclblpy)
-   - API docs Scailable (no explanation of what the stuff does): [https://docs.sclbl.net](https://docs.sclbl.net)
-- **Get an account (page does not mention accounts, link destination is the same as above):** [https://admin.sclbl.net/signup.html](https://admin.sclbl.net/signup.html) 
+   - API docs Scailable: [https://docs.sclbl.net](https://docs.sclbl.net)
+- **Get an account:** [https://admin.sclbl.net/signup.html](https://admin.sclbl.net/signup.html) 
 - **Install the AI manager:**
    - Locally: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager)
    - On an advantech device: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![PyPI Release](https://github.com/scailable/sclblpy/workflows/PyPI%20Release/badge.svg)](https://pypi.org/project/sclblpy/)
 
 
-DISCLAIMER: Sclblpy is undergoing changes, most notably we will focus on .onnx from now on, meaning sklearn and similar packages are no longer supported as well as the removal of the `run()` function.
-Expect unstable APIs!
-If you're the maintainer of a project and run into problems, feel free to send us a message at support@scailable.net
+Changelog: the package is currently undergoing a major rework. We try to keep the below up to date, but some features might be stubs. 
+Most relevant is the removal of support for Scikit learn in favor of focussing fully on ONNX.
+1. Removal of support for additional packages - most importantly in the 'upload()' function which now will throw an error if `model_type` isn't onnx
+2. the `run()` function is going to be replaced by a function that allows the user to test their local setup; and as such is a stub
+
 
 `sclblpy` is the core python package provided by Scailable for interacting with our API. The scope of this package is (roughly):
 1. upload an `.onnx` model to the admin console
@@ -13,8 +15,7 @@ If you're the maintainer of a project and run into problems, feel free to send u
 3. (upcoming) test device deployment
 
 
-NOTE: the package is currently undergoing a major rework. We try to keep the below up to date, but some features might be stubs. 
-Most relevant is the removal of support for Scikit learn in favor of focussing fully on ONNX.
+
 
 Also, there will probably be breaking changes in the API in one of the upcoming releases.
 
@@ -28,7 +29,7 @@ Also, there will probably be breaking changes in the API in one of the upcoming 
    - API docs Scailable: [https://docs.sclbl.net](https://docs.sclbl.net)
 - **Get an account:** [https://admin.sclbl.net/signup.html](https://admin.sclbl.net/signup.html) 
 - **Install the AI manager:**
-   - Locally: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager)
+   - on any Linux device: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager)
    - On an advantech device: [https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals)
 
 ## Background
@@ -186,6 +187,6 @@ neccesary for the `sclblpy` package to run.
 the toolchain and user-management function. These are useful when running the Scailable stack locally. Also the method `_toggle_debug_mode()` can
 be used for troubleshooting (this will raise exceptions and provide a trace upon errors).
 * Docs generated using `pdoc --html --html-dir docs sclblpy/main.py`
-
+* We are actively developing our stack; we try to list changes from one version to the next as clearly as possible. If you find any errors or issues please add an issue to this repo."
 If you are having trouble using the `sclblpy` package, please [submit an issue to our github](https://github.com/scailable/sclblpy/issues/new), 
 we will try to fix it as quickly as possible!

--- a/sclblpy/main.py
+++ b/sclblpy/main.py
@@ -22,7 +22,7 @@ def welcome():
 
 
 # upload is a wrapper for upload_onnx and upload_sklearn to provide backwards compatibility:
-def upload(mod, features, docs={}, email=True, model_type="sklearn", _keep=False) -> bool:
+def upload(mod, features, docs={}, email=True, model_type="onnx", _keep=False) -> bool:
     """upload uploads a trained AI/ML model to Scailable.
 
     The upload function is the main workhorse of the sclblpy package but effectively provides a
@@ -72,14 +72,7 @@ def upload(mod, features, docs={}, email=True, model_type="sklearn", _keep=False
         UploadModelError if unable to successfully bundle and upload the model.
     """
     if model_type == "sklearn":
-        if features == "":
-            if not glob.SILENT:
-                print("FATAL: You cannot upload a sklearn model with an empty string as feature vector.")
-            if glob.DEBUG:
-                raise UploadModelError("Cannot upload sklearn model with empty string as feature vector.")
-            return False
-        if not upload_sklearn(mod, features, docs, email, _keep):
-            return False
+        raise UploadModelError("sklearn is no longer supported. Please use .onnx. In urgent cases, get in contact with us at support@scailable.net")
     elif model_type == "onnx":
         if not upload_onnx(mod, features, docs, email):
             return False

--- a/sclblpy_tutorial.ipynb
+++ b/sclblpy_tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -130,7 +130,7 @@
        ")"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,20 +146,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key input for dynamic axes is not a valid input/output name\n",
-      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n",
-      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key output for dynamic axes is not a valid input/output name\n",
-      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Input to the model\n",
     "x = torch.randn(batch_size, 1, 224, 224, requires_grad=True)\n",
@@ -187,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -243,13 +232,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
     "\n",
-    "time.sleep(15)"
+    "time.sleep(15)\n",
+    "\n",
+    "\n",
+    "#remove file\n",
+    "import os\n",
+    "if os.path.exists(\"super_resolution.onnx\"):\n",
+    "    os.remove(\"super_resolution.onnx\")\n",
+    "else:\n",
+    "    print(\"The file does not exist\")"
    ]
   },
   {
@@ -274,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -317,28 +314,49 @@
       "text/plain": [
        "[{'agent': 'toolchain',\n",
        "  'alias': '',\n",
-       "  'cfid': '370221a2-8346-11ec-8685-9600004e79cc',\n",
-       "  'created_day': '01 Feb 2022',\n",
-       "  'created_time': '11:03:42',\n",
+       "  'cfid': '032e06a4-83fd-11ec-8685-9600004e79cc',\n",
+       "  'created_day': '02 Feb 2022',\n",
+       "  'created_time': '08:52:13',\n",
        "  'cycles': '1',\n",
        "  'docs': 'A long .md thing....',\n",
        "  'exampleinput': '',\n",
        "  'exampleoutput': '',\n",
-       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-33717467-8346-11ec-9e8f-9600004e7a82.wasm',\n",
-       "  'id': 551,\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-ff4fc281-83fc-11ec-9517-9600004e7a82.wasm',\n",
+       "  'id': 553,\n",
        "  'input_driver': '',\n",
        "  'input_driver_details': '',\n",
        "  'jwt_secured': False,\n",
-       "  'location': 'https://cdn.sclbl.net:8000/file/370221a2-8346-11ec-8685-9600004e79cc.wasm',\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/032e06a4-83fd-11ec-8685-9600004e79cc.wasm',\n",
        "  'name': 'Faux Superresolution ONNX',\n",
        "  'output_driver': '',\n",
        "  'output_driver_details': '',\n",
        "  'profit': '0.1',\n",
-       "  'updated_day': '01 Feb 2022',\n",
-       "  'updated_time': '11:03:42'}]"
+       "  'updated_day': '02 Feb 2022',\n",
+       "  'updated_time': '08:52:13'},\n",
+       " {'agent': 'toolchain',\n",
+       "  'alias': '',\n",
+       "  'cfid': 'c60326d6-83fc-11ec-8685-9600004e79cc',\n",
+       "  'created_day': '02 Feb 2022',\n",
+       "  'created_time': '08:50:31',\n",
+       "  'cycles': '1',\n",
+       "  'docs': 'A long .md thing....',\n",
+       "  'exampleinput': '',\n",
+       "  'exampleoutput': '',\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-c2146766-83fc-11ec-a82c-9600004e7a82.wasm',\n",
+       "  'id': 552,\n",
+       "  'input_driver': '',\n",
+       "  'input_driver_details': '',\n",
+       "  'jwt_secured': False,\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/c60326d6-83fc-11ec-8685-9600004e79cc.wasm',\n",
+       "  'name': 'Faux Superresolution ONNX',\n",
+       "  'output_driver': '',\n",
+       "  'output_driver_details': '',\n",
+       "  'profit': '0.1',\n",
+       "  'updated_day': '02 Feb 2022',\n",
+       "  'updated_time': '08:50:31'}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -350,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,12 +388,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Assign the model to a device"
+    "## Assign the model to a device\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -392,7 +411,7 @@
        "True"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -410,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -427,7 +446,7 @@
        "True"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,14 +475,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Endpoint with cfid 370221a2-8346-11ec-8685-9600004e79cc was successfully deleted.\n"
+      "Endpoint with cfid 032e06a4-83fd-11ec-8685-9600004e79cc was successfully deleted.\n"
      ]
     },
     {
@@ -472,7 +491,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -483,21 +502,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You currently do not own any active endpoints.\n",
+      "You currently own the following endpoints:\n",
       "\n",
-      "Need help getting started?\n",
-      " - See the sclblpy docs at https://pypi.org/project/sclblpy/.\n",
-      " - See our getting started tutorial at https://github.com/scailable/sclbl-tutorials/tree/master/sclbl-101-getting-started.\n",
-      " - Or, login to your admin at https://admin.sclbl.net. \n",
+      "  1: Faux Superresolution ONNX, \n",
+      "   - cfid: c60326d6-83fc-11ec-8685-9600004e79cc \n",
+      "   - example: https://admin.sclbl.net/run.html?cfid=c60326d6-83fc-11ec-8685-9600004e79cc&exin= \n",
       "\n",
-      "NOTE: if you have just uploaded a model, please check your email; we will let you know when its available!\n",
+      "Login at https://admin.sclbl.net to administer your endpoints and see integration examples.\n",
       "\n"
      ]
     },
@@ -507,7 +525,7 @@
        "True"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -515,6 +533,20 @@
    "source": [
     "sp.models()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/sclblpy_tutorial.ipynb
+++ b/sclblpy_tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -130,7 +130,7 @@
        ")"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,9 +146,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key input for dynamic axes is not a valid input/output name\n",
+      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n",
+      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key output for dynamic axes is not a valid input/output name\n",
+      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n"
+     ]
+    }
+   ],
    "source": [
     "# Input to the model\n",
     "x = torch.randn(batch_size, 1, 224, 224, requires_grad=True)\n",
@@ -176,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -217,13 +228,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -232,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -314,49 +318,28 @@
       "text/plain": [
        "[{'agent': 'toolchain',\n",
        "  'alias': '',\n",
-       "  'cfid': '032e06a4-83fd-11ec-8685-9600004e79cc',\n",
+       "  'cfid': 'bdf3a775-8400-11ec-8685-9600004e79cc',\n",
        "  'created_day': '02 Feb 2022',\n",
-       "  'created_time': '08:52:13',\n",
+       "  'created_time': '09:18:54',\n",
        "  'cycles': '1',\n",
        "  'docs': 'A long .md thing....',\n",
        "  'exampleinput': '',\n",
        "  'exampleoutput': '',\n",
-       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-ff4fc281-83fc-11ec-9517-9600004e7a82.wasm',\n",
-       "  'id': 553,\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-ba2e37d4-8400-11ec-a598-9600004e7a82.wasm',\n",
+       "  'id': 555,\n",
        "  'input_driver': '',\n",
        "  'input_driver_details': '',\n",
        "  'jwt_secured': False,\n",
-       "  'location': 'https://cdn.sclbl.net:8000/file/032e06a4-83fd-11ec-8685-9600004e79cc.wasm',\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/bdf3a775-8400-11ec-8685-9600004e79cc.wasm',\n",
        "  'name': 'Faux Superresolution ONNX',\n",
        "  'output_driver': '',\n",
        "  'output_driver_details': '',\n",
        "  'profit': '0.1',\n",
        "  'updated_day': '02 Feb 2022',\n",
-       "  'updated_time': '08:52:13'},\n",
-       " {'agent': 'toolchain',\n",
-       "  'alias': '',\n",
-       "  'cfid': 'c60326d6-83fc-11ec-8685-9600004e79cc',\n",
-       "  'created_day': '02 Feb 2022',\n",
-       "  'created_time': '08:50:31',\n",
-       "  'cycles': '1',\n",
-       "  'docs': 'A long .md thing....',\n",
-       "  'exampleinput': '',\n",
-       "  'exampleoutput': '',\n",
-       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-c2146766-83fc-11ec-a82c-9600004e7a82.wasm',\n",
-       "  'id': 552,\n",
-       "  'input_driver': '',\n",
-       "  'input_driver_details': '',\n",
-       "  'jwt_secured': False,\n",
-       "  'location': 'https://cdn.sclbl.net:8000/file/c60326d6-83fc-11ec-8685-9600004e79cc.wasm',\n",
-       "  'name': 'Faux Superresolution ONNX',\n",
-       "  'output_driver': '',\n",
-       "  'output_driver_details': '',\n",
-       "  'profit': '0.1',\n",
-       "  'updated_day': '02 Feb 2022',\n",
-       "  'updated_time': '08:50:31'}]"
+       "  'updated_time': '09:18:54'}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -411,7 +394,7 @@
        "True"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -429,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +429,7 @@
        "True"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,14 +458,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Endpoint with cfid 032e06a4-83fd-11ec-8685-9600004e79cc was successfully deleted.\n"
+      "Endpoint with cfid bdf3a775-8400-11ec-8685-9600004e79cc was successfully deleted.\n"
      ]
     },
     {
@@ -491,7 +474,7 @@
        "True"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -502,20 +485,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You currently own the following endpoints:\n",
+      "You currently do not own any active endpoints.\n",
       "\n",
-      "  1: Faux Superresolution ONNX, \n",
-      "   - cfid: c60326d6-83fc-11ec-8685-9600004e79cc \n",
-      "   - example: https://admin.sclbl.net/run.html?cfid=c60326d6-83fc-11ec-8685-9600004e79cc&exin= \n",
+      "Need help getting started?\n",
+      " - See the sclblpy docs at https://pypi.org/project/sclblpy/.\n",
+      " - See our getting started tutorial at https://github.com/scailable/sclbl-tutorials/tree/master/sclbl-101-getting-started.\n",
+      " - Or, login to your admin at https://admin.sclbl.net. \n",
       "\n",
-      "Login at https://admin.sclbl.net to administer your endpoints and see integration examples.\n",
+      "NOTE: if you have just uploaded a model, please check your email; we will let you know when its available!\n",
       "\n"
      ]
     },
@@ -525,7 +509,7 @@
        "True"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,20 +517,6 @@
    "source": [
     "sp.models()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/sclblpy_tutorial.ipynb
+++ b/sclblpy_tutorial.ipynb
@@ -1,0 +1,575 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sclblpy import main as sp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sclblpy \n",
+    "Sclblpy allows you to upload a `.onnx` model to your sclbl admin that can subsequently be assigned to a device that has previously been registered on your account.\n",
+    "\n",
+    "\n",
+    "## (preliminary) make an account\n",
+    "\n",
+    "To make an account, visit [Scailable](https://admin.sclbl.net/signup.html)\n",
+    "\n",
+    "## (preliminary) register at least one device\n",
+    "\n",
+    "To register a device, follow the tutorial [here](https://github.com/scailable/sclbl-tutorials/tree/master/solutions-manuals/sclbl-local-ai-manager). You'll be required to get a license as well - just apply for one and you'll receive a local evaluation copy (or use your previously obtained one, or get in contact with us)\n",
+    "\n",
+    "If you've read the above already and are only looking for the command, it's `wget -q -O - https://get.sclbl.net | sudo bash` or `sudo /opt/sclbl/etc/init startui` if you've already installed the manager. NOTE: obviously do not run `sudo` commands if you're not sure what you're doing! \n",
+    "\n",
+    "NOTE: the device's device manager has to be running during this tutorial, otherwise the assignment will (somehwat obviously) not work.\n",
+    "\n",
+    "## sign in\n",
+    "\n",
+    "To use the package, you'll have to sign in with the username and password you've received in the previous step\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (optional) build a model\n",
+    "\n",
+    "While most `.onnx` files will work out of the box with sclblpy, many of you will aim to use sclblpy to deploy some kind of Neural Network trained in e.g. Pytorch. We'll show you briefly how to export a Neural Network from the torch.nn.Module ... module to `onnx`, but feel free to use your own model, as long as it can be exported to `onnx` (one caveat: Not every operator is currently supported, find a list of the ones that work [here](https://github.com/scailable/sclblonnx/blob/master/sclblonnx/supported_onnx.json).\n",
+    "\n",
+    "Our example won't even be trained, since we're only interested in the deployment part, essentially we'll be doing the first few steps from https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html; feel free to do the rest of the tutorial as well!\n",
+    "\n",
+    "\n",
+    "NOTE: `pixel_shuffle()` is not yet supported by our runtime, so we have to remove it before conversion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SuperResolutionNet(\n",
+      "  (relu): ReLU()\n",
+      "  (conv1): Conv2d(1, 64, kernel_size=(5, 5), stride=(1, 1), padding=(2, 2))\n",
+      "  (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "  (conv3): Conv2d(64, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      "  (conv4): Conv2d(32, 9, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.init as init\n",
+    "\n",
+    "\n",
+    "class SuperResolutionNet(nn.Module):\n",
+    "    def __init__(self, upscale_factor, inplace=False):\n",
+    "        super(SuperResolutionNet, self).__init__()\n",
+    "\n",
+    "        self.relu = nn.ReLU(inplace=inplace)\n",
+    "        self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))\n",
+    "        self.conv2 = nn.Conv2d(64, 64, (3, 3), (1, 1), (1, 1))\n",
+    "        self.conv3 = nn.Conv2d(64, 32, (3, 3), (1, 1), (1, 1))\n",
+    "        self.conv4 = nn.Conv2d(32, upscale_factor ** 2, (3, 3), (1, 1), (1, 1))\n",
+    "        #self.pixel_shuffle = nn.PixelShuffle(upscale_factor)\n",
+    "\n",
+    "        self._initialize_weights()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.relu(self.conv1(x))\n",
+    "        x = self.relu(self.conv2(x))\n",
+    "        x = self.relu(self.conv3(x))\n",
+    "        #x = self.pixel_shuffle(self.conv4(x))\n",
+    "        return x\n",
+    "\n",
+    "    def _initialize_weights(self):\n",
+    "        init.orthogonal_(self.conv1.weight, init.calculate_gain('relu'))\n",
+    "        init.orthogonal_(self.conv2.weight, init.calculate_gain('relu'))\n",
+    "        init.orthogonal_(self.conv3.weight, init.calculate_gain('relu'))\n",
+    "        init.orthogonal_(self.conv4.weight)\n",
+    "\n",
+    "# Create the super-resolution model by using the above model definition.\n",
+    "torch_model = SuperResolutionNet(upscale_factor=3)\n",
+    "\n",
+    "print(torch_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So now we have our model, we'll call torch.eval() before we convert it to onnx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SuperResolutionNet(\n",
+       "  (relu): ReLU()\n",
+       "  (conv1): Conv2d(1, 64, kernel_size=(5, 5), stride=(1, 1), padding=(2, 2))\n",
+       "  (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "  (conv3): Conv2d(64, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "  (conv4): Conv2d(32, 9, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       ")"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "batch_size = 1    # just a random number\n",
+    "\n",
+    "\n",
+    "# set the model to inference mode\n",
+    "torch_model.eval()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key input for dynamic axes is not a valid input/output name\n",
+      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n",
+      "/home/thomas/anaconda3/lib/python3.7/site-packages/torch/onnx/utils.py:718: UserWarning: Provided key output for dynamic axes is not a valid input/output name\n",
+      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Input to the model\n",
+    "x = torch.randn(batch_size, 1, 224, 224, requires_grad=True)\n",
+    "torch_out = torch_model(x)\n",
+    "\n",
+    "# Export the model\n",
+    "torch.onnx.export(torch_model,               # model being run\n",
+    "                  x,                         # model input (or a tuple for multiple inputs)\n",
+    "                  \"super_resolution.onnx\",   # where to save the model (can be a file or file-like object)\n",
+    "                  export_params=True,        # store the trained parameter weights inside the model file\n",
+    "                  opset_version=10,          # the ONNX version to export the model to\n",
+    "                  do_constant_folding=True,  # whether to execute constant folding for optimization\n",
+    "                  input_names = ['input'],   # the model's input names\n",
+    "                  output_names = ['output'], # the model's output names\n",
+    "                  dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes\n",
+    "                                'output' : {0 : 'batch_size'}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## write some docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs = {}\n",
+    "docs['name'] = \"Faux Superresolution ONNX\"\n",
+    "docs['documentation'] = \"A long .md thing....\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload the model to your admin (where we call the thing we upload stuff to?)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your ONNX file was successfully uploaded to Scailable!\n",
+      "NOTE: After transpiling, we will send you an email and your model will be available at https://admin.sclbl.net.\n",
+      "Or, alternatively, you can use the 'models()' function to list all your uploaded models. \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "check = sp.upload(\"super_resolution.onnx\",\"\",docs)\n",
+    "\n",
+    "\n",
+    "\n",
+    "#note: this will take a bit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (optional) wait for a few seconds to give the server time to convert the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "time.sleep(15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (optional) check if the model has been uploaded\n",
+    "\n",
+    "Go to https://admin.sclbl.net/index.html to check if your model has been uploaded.\n",
+    "\n",
+    "Here you'll be able to check out your model's stats and assign a driver."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get the id(s) of your device(s)\n",
+    "\n",
+    "In order to interact with your devices, you'll need the id of the model you'll want to interact with. Luckily, that's easy as a pie. The `_verbose = False` suppresses written output, the `_return=True` forces the method to return the data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devices = sp.devices(_return=True,_verbose=False)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`devices` will be a list of dictionaries containing a bunch of information about your devices, such as the id, did, rid, name, time of creation, runtime, ... However, this tutorial only requires `did` and `rid`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device= [x for x in devices if x['name']=='My computer'][0]\n",
+    "device_did = device['did']\n",
+    "device_rid = device['rid']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get the model's ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'agent': 'toolchain',\n",
+       "  'alias': '',\n",
+       "  'cfid': 'a60bb366-8344-11ec-8685-9600004e79cc',\n",
+       "  'created_day': '01 Feb 2022',\n",
+       "  'created_time': '10:52:29',\n",
+       "  'cycles': '1',\n",
+       "  'docs': 'A long .md thing....',\n",
+       "  'exampleinput': '',\n",
+       "  'exampleoutput': '',\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-a24af1bb-8344-11ec-8c6c-9600004e7a82.wasm',\n",
+       "  'id': 549,\n",
+       "  'input_driver': '',\n",
+       "  'input_driver_details': '',\n",
+       "  'jwt_secured': False,\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/a60bb366-8344-11ec-8685-9600004e79cc.wasm',\n",
+       "  'name': 'Faux Superresolution ONNX',\n",
+       "  'output_driver': '',\n",
+       "  'output_driver_details': '',\n",
+       "  'profit': '0.1',\n",
+       "  'updated_day': '01 Feb 2022',\n",
+       "  'updated_time': '10:52:29'},\n",
+       " {'agent': 'toolchain',\n",
+       "  'alias': '',\n",
+       "  'cfid': '8f6ad718-8344-11ec-8685-9600004e79cc',\n",
+       "  'created_day': '01 Feb 2022',\n",
+       "  'created_time': '10:51:51',\n",
+       "  'cycles': '1',\n",
+       "  'docs': 'A long .md thing....',\n",
+       "  'exampleinput': '',\n",
+       "  'exampleoutput': '',\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-8bcb10be-8344-11ec-bb92-9600004e7a82.wasm',\n",
+       "  'id': 548,\n",
+       "  'input_driver': '',\n",
+       "  'input_driver_details': '',\n",
+       "  'jwt_secured': False,\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/8f6ad718-8344-11ec-8685-9600004e79cc.wasm',\n",
+       "  'name': 'Faux Superresolution ONNX',\n",
+       "  'output_driver': '',\n",
+       "  'output_driver_details': '',\n",
+       "  'profit': '0.1',\n",
+       "  'updated_day': '01 Feb 2022',\n",
+       "  'updated_time': '10:51:51'}]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "models = sp.models(_return=True, _verbose=False)\n",
+    "models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = [x for x in models if x['name'] == docs['name']][0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_cfid = model['cfid']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assign the model to a device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your assignment has been added. \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp.assign(model_cfid, device_did, device_rid, _verbose=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update a model's docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your model documentation has been updated. \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs = {}\n",
+    "docs['name'] = \"a newly named Superresolution ONNX\"\n",
+    "docs['documentation'] = \"An even longer .md thing....\"\n",
+    "\n",
+    "sp.update_docs(model_cfid, docs)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## redeploy\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## delte model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Endpoint with cfid a60bb366-8344-11ec-8685-9600004e79cc was successfully deleted.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp.delete_model(model_cfid)  # Where cfid is the compute function id\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You currently own the following endpoints:\n",
+      "\n",
+      "  1: Faux Superresolution ONNX, \n",
+      "   - cfid: 8f6ad718-8344-11ec-8685-9600004e79cc \n",
+      "   - example: https://admin.sclbl.net/run.html?cfid=8f6ad718-8344-11ec-8685-9600004e79cc&exin= \n",
+      "\n",
+      "Login at https://admin.sclbl.net to administer your endpoints and see integration examples.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sp.models()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sclblpy_tutorial.ipynb
+++ b/sclblpy_tutorial.ipynb
@@ -317,46 +317,25 @@
       "text/plain": [
        "[{'agent': 'toolchain',\n",
        "  'alias': '',\n",
-       "  'cfid': 'a60bb366-8344-11ec-8685-9600004e79cc',\n",
+       "  'cfid': '370221a2-8346-11ec-8685-9600004e79cc',\n",
        "  'created_day': '01 Feb 2022',\n",
-       "  'created_time': '10:52:29',\n",
+       "  'created_time': '11:03:42',\n",
        "  'cycles': '1',\n",
        "  'docs': 'A long .md thing....',\n",
        "  'exampleinput': '',\n",
        "  'exampleoutput': '',\n",
-       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-a24af1bb-8344-11ec-8c6c-9600004e7a82.wasm',\n",
-       "  'id': 549,\n",
+       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-33717467-8346-11ec-9e8f-9600004e7a82.wasm',\n",
+       "  'id': 551,\n",
        "  'input_driver': '',\n",
        "  'input_driver_details': '',\n",
        "  'jwt_secured': False,\n",
-       "  'location': 'https://cdn.sclbl.net:8000/file/a60bb366-8344-11ec-8685-9600004e79cc.wasm',\n",
+       "  'location': 'https://cdn.sclbl.net:8000/file/370221a2-8346-11ec-8685-9600004e79cc.wasm',\n",
        "  'name': 'Faux Superresolution ONNX',\n",
        "  'output_driver': '',\n",
        "  'output_driver_details': '',\n",
        "  'profit': '0.1',\n",
        "  'updated_day': '01 Feb 2022',\n",
-       "  'updated_time': '10:52:29'},\n",
-       " {'agent': 'toolchain',\n",
-       "  'alias': '',\n",
-       "  'cfid': '8f6ad718-8344-11ec-8685-9600004e79cc',\n",
-       "  'created_day': '01 Feb 2022',\n",
-       "  'created_time': '10:51:51',\n",
-       "  'cycles': '1',\n",
-       "  'docs': 'A long .md thing....',\n",
-       "  'exampleinput': '',\n",
-       "  'exampleoutput': '',\n",
-       "  'filename': '91962e67-9bda-42d8-b5b7-7529314dde5e-8bcb10be-8344-11ec-bb92-9600004e7a82.wasm',\n",
-       "  'id': 548,\n",
-       "  'input_driver': '',\n",
-       "  'input_driver_details': '',\n",
-       "  'jwt_secured': False,\n",
-       "  'location': 'https://cdn.sclbl.net:8000/file/8f6ad718-8344-11ec-8685-9600004e79cc.wasm',\n",
-       "  'name': 'Faux Superresolution ONNX',\n",
-       "  'output_driver': '',\n",
-       "  'output_driver_details': '',\n",
-       "  'profit': '0.1',\n",
-       "  'updated_day': '01 Feb 2022',\n",
-       "  'updated_time': '10:51:51'}]"
+       "  'updated_time': '11:03:42'}]"
       ]
      },
      "execution_count": 10,
@@ -484,7 +463,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Endpoint with cfid a60bb366-8344-11ec-8685-9600004e79cc was successfully deleted.\n"
+      "Endpoint with cfid 370221a2-8346-11ec-8685-9600004e79cc was successfully deleted.\n"
      ]
     },
     {
@@ -511,13 +490,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You currently own the following endpoints:\n",
+      "You currently do not own any active endpoints.\n",
       "\n",
-      "  1: Faux Superresolution ONNX, \n",
-      "   - cfid: 8f6ad718-8344-11ec-8685-9600004e79cc \n",
-      "   - example: https://admin.sclbl.net/run.html?cfid=8f6ad718-8344-11ec-8685-9600004e79cc&exin= \n",
+      "Need help getting started?\n",
+      " - See the sclblpy docs at https://pypi.org/project/sclblpy/.\n",
+      " - See our getting started tutorial at https://github.com/scailable/sclbl-tutorials/tree/master/sclbl-101-getting-started.\n",
+      " - Or, login to your admin at https://admin.sclbl.net. \n",
       "\n",
-      "Login at https://admin.sclbl.net to administer your endpoints and see integration examples.\n",
+      "NOTE: if you have just uploaded a model, please check your email; we will let you know when its available!\n",
       "\n"
      ]
     },
@@ -535,20 +515,6 @@
    "source": [
     "sp.models()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
+ augmented documentation
+ removed model_type sklearn: now informs user that sklearn is no longer supported
+ added sclblpy_tutorial.ipynb which (should) documents all important endpoints and can be used as basic test for later removing all mentions of sklearn